### PR TITLE
url fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,7 @@ download_swtor() {
 
 download_swtor_shortcut_zip() {
   echo -e "${PURPLE}\t(3/3) Downloading SWTOR.zip from https://github.com/AgentRG/swtor_on_mac/${NONE}"
-  wget https://github.com/AgentRG/swtor_on_mac/raw/AgentRG-patch-14/SWTOR.app
+  wget https://github.com/AgentRG/swtor_on_mac/raw/master/SWTOR.app
 }
 
 move_swtor_fix() {


### PR DESCRIPTION
1. Changing the url in download_swtor_shortcut_zip to point to the master branch.